### PR TITLE
Add script to check schemas, plus minor updates

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Check
         run: ./scripts/check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,19 @@
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+      - name: Check
+        run: ./scripts/check

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.pyc

--- a/schema/config.json
+++ b/schema/config.json
@@ -2,17 +2,11 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Outpack configuration schema",
     "description": "Common configuration settings. Implementations may add additional properties, but these are the core.",
-    "version": "0.1.0",
+    "version": "0.1.1",
 
     "type": "object",
 
     "properties": {
-        "schema_version": {
-            "description": "Schema version, used to manage migrations",
-            "type": "string",
-            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
-        },
-
         "core": {
             "type": "object",
             "properties": {
@@ -31,19 +25,6 @@
             },
             "required": ["path_archive", "use_file_store", "hash_algorithm"],
             "additionalProperties": false
-        },
-
-        "logging": {
-            "type": "object",
-            "properties": {
-                "threshold": {
-                    "enum": ["info", "debug", "trace"]
-                },
-                "console": {
-                    "type": "boolean"
-                }
-            },
-            "required": ["threshold", "console"]
         },
 
         "location": {
@@ -66,5 +47,5 @@
         }
     },
 
-    "required": ["schema_version", "core", "location"]
+    "required": ["core", "location"]
 }

--- a/schema/git.json
+++ b/schema/git.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Outpack git information",
     "description": "Information about source versioning with git",
-    "version": "0.1.0",
+    "version": "0.1.1",
 
     "type": "object",
     "properties": {

--- a/schema/hash.json
+++ b/schema/hash.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "File hash",
     "description": "A hash of a file, including the algorithm name (e.g., md5, sha256)",
-    "version": "0.1.0",
+    "version": "0.1.1",
 
     "type": "string",
     "pattern": "^(md5|sha1|sha256|sha384|sha512):([0-9a-f]{16,})$"

--- a/schema/location.json
+++ b/schema/location.json
@@ -2,16 +2,10 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "outpack location download schema",
     "description": "Information about where a packet comes from",
-    "version": "0.1.0",
+    "version": "0.1.1",
 
     "type": "object",
     "properties": {
-        "schema_version": {
-            "description": "Schema version, used to manage migrations",
-            "type": "string",
-            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
-        },
-
         "packet": {
             "$ref": "packet-id.json"
         },
@@ -25,5 +19,5 @@
             "$ref": "hash.json"
         }
     },
-    "required": ["schema_version", "packet", "time", "hash"]
+    "required": ["packet", "time", "hash"]
 }

--- a/schema/metadata.json
+++ b/schema/metadata.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Outpack metadata schema",
     "description": "This is the minimal schema, it is expected that implementations will want and need additional fields throughout",
-    "version": "0.1.0",
+    "version": "0.1.1",
 
     "type": "object",
     "properties": {

--- a/schema/packet-id.json
+++ b/schema/packet-id.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Outpack packet id",
     "description": "A globally unique identifier for any packet, composed of an encoded date (to millisecond accuracy) and random bytes",
-    "version": "0.1.0",
+    "version": "0.1.1",
 
     "type": "string",
     "pattern": "^([0-9]{8}-[0-9]{6})-([0-9a-f]{8})$"

--- a/scripts/check
+++ b/scripts/check
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+def check_file(path, version):
+    with path.open() as f:
+        dat = json.load(f)
+    version_found = dat["version"]
+    if version_found != version:
+        msg = f"{path.name} has version '{version_found}' not '{version}'"
+        raise Exception(msg)
+
+
+
+def check_dir(path, version):
+    errs = {}
+    for p in Path(path).iterdir():
+        try:
+            print(f"Checking {path}", end="")
+            check_file(p, version)
+            print(f"...ok")
+        except Exception as e:
+            print(f"...failed:\n  => {e}")
+            errs[p.name] = e
+    return errs
+
+
+if __name__ == "__main__":
+    check_dir("schema", "0.1.1")


### PR DESCRIPTION
The action here just runs some sanity checks for us: that all schemas have the same (known) version number and that they all parse as json. We can expand this as we need.

The changes to the schema:

* the logging section is removed from config.json
* the schema_version section is removed from config.json and location.json - neither of these need this change

These changes are fairly innocent I believe - any existing metadata still satisfies the schema as they allow additional properties. I will be updating orderly2 to change behaviour of logging in another PR