### PR TITLE
Allow a dependency to have no files

### DIFF
--- a/schema/metadata.json
+++ b/schema/metadata.json
@@ -88,7 +88,6 @@
                     },
                     "files": {
                         "type": "array",
-                        "minItems": 1,
                         "items": {
                             "type": "object",
                             "properties": {


### PR DESCRIPTION
The schema requires at least one file to be pulled in when declaring a dependency.

This requirement seems unnecessary. Having no dependencies is probably not very useful in practice, but it can help make integration tests that aren't concerned with file copying more concise. It also seems harmless to allow this scenario.