### PR TITLE
Make the Git SHA and branch null-able.

### DIFF
--- a/schema/git.json
+++ b/schema/git.json
@@ -7,11 +7,11 @@
     "type": "object",
     "properties": {
         "sha": {
-            "type": "string",
+            "type": ["string", "null"],
             "pattern": "^[0-9a-f]+$"
         },
         "branch": {
-            "type": "string"
+            "type": ["string", "null"]
         },
         "url": {
             "type": "array",
@@ -19,5 +19,6 @@
                 "type": "string"
             }
         }
-    }
+    },
+    "required": ["url", "sha", "branch"]
 }


### PR DESCRIPTION
These can happen if running a packet for a repository that is either empty or with a detached HEAD. I've added all the fields as explicitly required (although the entire git structure is still allowed to be missing from the top-level metadata object).